### PR TITLE
Fixed bug: 新版本下保存图片文字的透明度好像有点问题

### DIFF
--- a/src/styles/_colorName.scss
+++ b/src/styles/_colorName.scss
@@ -4,7 +4,8 @@
   font-size: calc(100px + 5vw);
   right: 0;
   top: 0;
-  opacity: .1;
+  color: rgba(0, 0, 0, .1);
+  opacity: 1;
   writing-mode: vertical-rl;
   white-space: nowrap;
   transform: translate(10%, -5%);
@@ -16,7 +17,7 @@
 }
 
 @keyframes fadeOut {
-  0% { opacity: .1; }
-  50% { opacity: .1; }
+  0% { opacity: 1; }
+  50% { opacity: 1; }
   100% { opacity: 0; }
 }


### PR DESCRIPTION
Root cause：html2canvas的bug。
为了避免opacity为0.1而污染verses element，初始化opacity为1，透明度改为用rgba实现。完全保留原有效果。