### PR TITLE
fix: remove outline border

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -228,7 +228,7 @@ class App extends Component {
     const sketches = { blobs, waves };
 
     return selected ? (
-      <div className="App" tabIndex="-1" onKeyDown={this.handleKeyDown}>
+      <div className="App" tabIndex="-1" onKeyDown={this.handleKeyDown} style={{ outline: 'none' }}>
         <GlobalStyle />
         {selected === WAVES && (
           <ColorName


### PR DESCRIPTION
when we press space bar to controll the animation, can see a tiny line at the top of page:
![image](https://user-images.githubusercontent.com/7373882/189313237-f93b7eb7-4d85-4e6e-8afd-1bf0a791cd2d.png)
caused by the browser default outline, can we remove it for more naturalness and beauty?